### PR TITLE
Fix for error on form caching. 

### DIFF
--- a/src/org/odk/collect/android/utilities/ApkUtils.java
+++ b/src/org/odk/collect/android/utilities/ApkUtils.java
@@ -97,13 +97,8 @@ public class ApkUtils {
                    if(Externalizable.class.isAssignableFrom(prototype)) {
                        classNames.add(cn);
                    }
-               } catch(IllegalAccessError e) {
-                   //nothing
-               } catch (SecurityException e) {
-                   
-               } catch (RuntimeException e){
-                   
-               } catch(Exception e) {
+               } catch(Throwable e) {
+                   //nothing should every make this crash
                }
            }
        }


### PR DESCRIPTION
We try to cache our forms in the serialized format to make them _waaay_ faster to load, but this gets hindered by the reflection in places we don't care about. 

This fixes a bug that was preventing errors from slipping through the loading try/catch
