### PR TITLE
Fix for Required questions on keyboard focus

### DIFF
--- a/src/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/src/org/odk/collect/android/widgets/QuestionWidget.java
@@ -228,6 +228,9 @@ public abstract class QuestionWidget extends LinearLayout {
      * will be fully visible in addition to the subview.
      */
     private void requestChildViewOnScreen(View child) {
+        //Take focus so the user can be prepared to interact with this question, since
+        //they will need to be fixing the input
+        acceptFocus();
         
         //Get the rectangle that wants to put itself on the screen
         Rect vitalPortion = new Rect();


### PR DESCRIPTION
Fix for FB#144824 - When users get a validation error on a question with text input, the text input now receives focus.
