### PR TITLE
Crash Fix - Multiselect Option Population

### DIFF
--- a/src/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/src/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -72,25 +72,6 @@ public class SelectMultiWidget extends QuestionWidget {
                 // no checkbox group so id by answer + offset
                 final CheckBox c = new CheckBox(getContext());
 
-                // when clicked, check for readonly before toggling
-                c.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-                	/*
-                	 * (non-Javadoc)
-                	 * @see android.widget.CompoundButton.OnCheckedChangeListener#onCheckedChanged(android.widget.CompoundButton, boolean)
-                	 */
-                    @Override
-                    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                        if (!mCheckboxInit && mPrompt.isReadOnly()) {
-                            if (buttonView.isChecked()) {
-                                buttonView.setChecked(false);
-                            } else {
-                                buttonView.setChecked(true);
-                            }
-                        }
-                        widgetEntryChanged();
-                    }
-                });
-
                 c.setId(buttonIdBase + i);
                 c.setText(prompt.getSelectChoiceText(mItems.get(i)));
                 c.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mAnswerFontsize);
@@ -108,6 +89,29 @@ public class SelectMultiWidget extends QuestionWidget {
                     }
 
                 }
+                
+                //Note: This gets fired during setup as well, so this listener should only
+                //be added after everything about the checkbox is set up
+                
+                // when clicked, check for readonly before toggling
+                c.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                    /*
+                     * (non-Javadoc)
+                     * @see android.widget.CompoundButton.OnCheckedChangeListener#onCheckedChanged(android.widget.CompoundButton, boolean)
+                     */
+                    @Override
+                    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                        if (!mCheckboxInit && mPrompt.isReadOnly()) {
+                            if (buttonView.isChecked()) {
+                                buttonView.setChecked(false);
+                            } else {
+                                buttonView.setChecked(true);
+                            }
+                        }
+                        widgetEntryChanged();
+                    }
+                });
+
                 mCheckboxes.add(c);
 
                 String audioURI = null;


### PR DESCRIPTION
Fixes navigating back and forth onto a multiselect item now that the check event is firing during initialization
