### PR TITLE
Fix serialization caching

### DIFF
--- a/src/org/odk/collect/android/jr/extensions/PollSensorAction.java
+++ b/src/org/odk/collect/android/jr/extensions/PollSensorAction.java
@@ -17,13 +17,13 @@ import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.GeoUtils;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.location.Location;
@@ -130,12 +130,12 @@ public class PollSensorAction extends Action implements LocationListener {
     
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
-        target = (TreeReference)ExtUtil.read(in, TreeReference.class, pf);
+        target = (TreeReference)ExtUtil.read(in, new ExtWrapNullable(TreeReference.class), pf);
     }
 
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
-        ExtUtil.write(out, target);
+        ExtUtil.write(out, new ExtWrapNullable(target));
     }
     
     /**

--- a/src/org/odk/collect/android/utilities/ApkUtils.java
+++ b/src/org/odk/collect/android/utilities/ApkUtils.java
@@ -46,6 +46,13 @@ public class ApkUtils {
             //Log.i("CLASS", cl);
             tree.addString(cl);
         }
+        
+        
+        classes = getClasses("org.odk.collect", c);
+        for(String cl : classes) {
+            //Log.i("CLASS", cl);
+            tree.addString(cl);
+        }
         } catch(Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Fixed a couple of bugs that were preventing forms with poll sensor data in them from loading on Android 5.0 (Couldn't quite tell why it wasn't crashing 4.0 devices)
